### PR TITLE
Remove complaint reference field from contact form

### DIFF
--- a/templates/incidents/contact_form.html
+++ b/templates/incidents/contact_form.html
@@ -79,9 +79,6 @@
       <div class="col">
         {% bootstrap_field wizard.form.incident_reference show_label=False %}
       </div>
-      <div class="col">
-        {% bootstrap_field wizard.form.complaint_reference show_label=False %}
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Removed complaint reference field from contact form.
Not the right place, as there is a question "Was there a complaint to the police" later.